### PR TITLE
should not fail when time ends .000Z, issue #21

### DIFF
--- a/src/Time/DateTime.elm
+++ b/src/Time/DateTime.elm
@@ -515,7 +515,7 @@ fromISO8601 input =
                     in
                         n * multiplier // padding // remainder
             in
-                convert <$> padding <*> digits
+                convert <$> padding <*> optional ( 0, 1 ) digits
 
         date =
             (,,)

--- a/tests/TestDateTime.elm
+++ b/tests/TestDateTime.elm
@@ -262,6 +262,8 @@ toFromISO8601 =
                 \() -> parseMs "2016-11-14T03:56:12.0012345Z" 1
             , test "fromISO8601 fractions are capped at millisecond precision with padding 2" <|
                 \() -> parseMs "2016-11-14T03:56:12.0001234Z" 0
+            , test "fromISO8601 fractions can be all zeros" <|
+                \() -> parseMs "2016-11-14T03:56:12.000Z" 0
             , fuzz2 (intRange -23 23) (intRange 0 59) "fromISO8601 parses offsets correctly" <|
                 \hour minute ->
                     let


### PR DESCRIPTION
This is all still kind of magic to me, all these infix versions of `map` (`<$>`), `andMap` (`<*>`) and all the other `<…`, `…>` or `<…>`.
Looking forward for review.