### PR TITLE
Repairs Date.addMonths, adds test case to cover this bug

### DIFF
--- a/src/Time/Date.elm
+++ b/src/Time/Date.elm
@@ -209,18 +209,18 @@ a Date, ensuring that the return value represents a valid Date.  Its
 semantics are the same as `addYears`.
 -}
 addMonths : Int -> Date -> Date
-addMonths months (Date ({ year, month, day } as date)) =
+addMonths months (Date { year, month, day }) =
     let
-        sign =
-            if year < 0 then
+        ms =
+            year * 12 + month - 1 + months
+
+        yo =
+            if ms < 0 then
                 -1
             else
-                1
-
-        ms =
-            abs year * 12 + month - 1 + months
+                0
     in
-        firstValid (sign * ms // 12) ((ms % 12) + 1) day
+        date (((ms - yo) // 12) + yo) ((ms % 12) + 1) day
 
 
 {-| days adds an exact number (positive or negative) of days to a

--- a/tests/TestDate.elm
+++ b/tests/TestDate.elm
@@ -118,6 +118,16 @@ adders =
                         date 1992 2 29
                 in
                     Expect.equal date1 date2
+        , fuzz3 (intRange -400 3000) (intRange 1 12) (intRange -100 100) "addMonths is revertable" <|
+            \year month addage ->
+                let
+                    date1 =
+                        date year month 1
+
+                    date2 =
+                        addMonths addage date1
+                in
+                    Expect.equal date1 (addMonths -addage date2)
         , fuzz int "addDays is absolute" <|
             \days ->
                 let


### PR DESCRIPTION
The method `Date.addMonths` fails around the year 0. For example, substracting
one month from 0-1-1 leads to 0-12-1 instead of -1-12-1. This is due to tricky
numbering of the months when considering negative years.

A test case is added with does fuzz testing to see if `Date.addMonths` is
revertable. To actually be revertable, the day is restricted to 1. It fails for
the old implementation, but passes with the new method.