### PR TITLE
switch to elm-community/parser-combinators

### DIFF
--- a/elm-package.json
+++ b/elm-package.json
@@ -14,7 +14,7 @@
         "Time.TimeZones"
     ],
     "dependencies": {
-        "Bogdanp/elm-combine": "3.0.0 <= v < 4.0.0",
+        "elm-community/parser-combinators": "1.1.0 <= v < 2.0.0",
         "elm-lang/core": "5.0.0 <= v < 6.0.0",
         "elm-lang/lazy": "2.0.0 <= v < 3.0.0"
     },


### PR DESCRIPTION
Hello!

I've encountered an issue while installing this library in a project which is already using [`elm-community/parser-combinators`](https://github.com/elm-community/parser-combinators). Both of this libraries are forks of [Bogdanp's](github.com/Bogdanp) original work which is no longer maintained.

I'm not sure if just this change resolves my original issue but it seems to be a first logical step in doing so.

This is the compiler error from project with both parser-combinators and elm-time:

```
Module build failed: Error: Compiler process exited with error Compilation failed
Problem in dependency Bogdanp/elm-combine 3.1.1

The elm-package.json constraints of 'Bogdanp/elm-combine' are probably
letting too much stuff through. Definitely open an issue on the relevant github
repo to get this fixed and save other people from this pain.

In the meantime, take a look through the direct dependencies of the broken
package and see if any of them have had releases recently. If you find the new
thing that is causing problems, you can artificially constrain things by adding
some extra constraints to your elm-package.json as a stopgap measure.
```