### PR TITLE
make docs more consistent

### DIFF
--- a/src/Time/Date.elm
+++ b/src/Time/Date.elm
@@ -29,7 +29,17 @@ represent any date of the proleptic Gregorian calendar.
 
 # Dates
 
-@docs Date, date, year, month, day, Weekday, weekday
+@docs Date
+
+
+# Constructing Dates
+
+@docs date, fromTuple, toTuple
+
+
+# Inspecting Dates
+
+@docs year, month, day, Weekday, weekday
 
 
 # Manipulating Dates
@@ -39,17 +49,12 @@ represent any date of the proleptic Gregorian calendar.
 
 # Comparing Dates
 
-@docs compare
-
-
-# Subtracting Dates
-
-@docs DateDelta, delta
+@docs compare, DateDelta, delta
 
 
 # Helper functions
 
-@docs toTuple, fromTuple, isValidDate, isLeapYear, daysInMonth
+@docs isValidDate, isLeapYear, daysInMonth
 
 -}
 
@@ -96,6 +101,7 @@ Invalid values are clamped to the nearest valid date.
     year d --> 2018
     month d --> 5
     day d --> 29
+
 -}
 date : Int -> Int -> Int -> Date
 date year month day =

--- a/src/Time/DateTime.elm
+++ b/src/Time/DateTime.elm
@@ -46,27 +46,32 @@ time of day.
 
 # DateTimes
 
-@docs DateTime, zero, epoch, dateTime, date, year, month, day, weekday, hour, minute, second, millisecond
+@docs DateTime
+
+
+# Constructing DateTimes
+
+@docs zero, epoch, dateTime, makeDateTime, fromTimestamp, toTimestamp, fromTuple, toTuple
+
+
+# Inspecting DateTimes
+
+@docs date, year, month, day, weekday, hour, minute, second, millisecond
 
 
 # Manipulating DateTimes
 
-@docs makeDateTime, setDate, setYear, setMonth, setDay, setHour, setMinute, setSecond, setMillisecond, addYears, addMonths, addDays, addHours, addMinutes, addSeconds, addMilliseconds
+@docs setDate, setYear, setMonth, setDay, setHour, setMinute, setSecond, setMillisecond, addYears, addMonths, addDays, addHours, addMinutes, addSeconds, addMilliseconds
 
 
 # Comparing DateTimes
 
-@docs compare
-
-
-# Subtracting DateTimes
-
-@docs DateTimeDelta, delta
+@docs compare, DateTimeDelta, delta
 
 
 # Helper functions
 
-@docs isValidTime, toTimestamp, fromTimestamp, toTuple, fromTuple
+@docs isValidTime
 
 
 # Deprecated
@@ -94,6 +99,7 @@ type DateTime
 DateTime values in terms of each of the different "units".
 
 See `Time.DateTime.delta` for an "aha!" example.
+
 -}
 type alias DateTimeDelta =
     { years : Int


### PR DESCRIPTION
I've noticed that docs sections are inconsistent between `Date`, `DateTime` and `ZonedDateTime`.

This PR makes them consistent. I've decided to take structure of `ZonedDateTime` as a starting point and aligned other modules with it. Though it can be done also other way around.

Lets use this PR as a starting point for the discussion.